### PR TITLE
Implemented read_only option for input pipes

### DIFF
--- a/kim/exception.py
+++ b/kim/exception.py
@@ -32,3 +32,7 @@ class FieldError(KimException):
 
 class FieldInvalid(KimException):
     pass
+
+
+class StopPipelineExecution(KimException):
+    pass

--- a/kim/pipelines/collection.py
+++ b/kim/pipelines/collection.py
@@ -5,7 +5,8 @@
 # This module is part of Kim and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from .base import Input, Output, get_data_from_source, update_output
+from .base import (Input, Output, marshal_input_pipe, marshal_output_pipe,
+                   serialize_input_pipe, serialize_output_pipe)
 
 
 def is_list(field, data):
@@ -28,6 +29,10 @@ def run_collection(collection_field, data, func):
 
 
 def marshall_collection(field, data):
+    """iterate over each item in ``data`` and marshal the item through the
+    wrapped field defined for this collection
+
+    """
     wrapped_field = field.opts.field
     output = [o for o in run_collection(field, data, wrapped_field.marshal)]
 
@@ -35,6 +40,10 @@ def marshall_collection(field, data):
 
 
 def serialize_collection(field, data):
+    """iterate over each item in ``data`` and serialize the item through the
+    wrapped field defined for this collection
+
+    """
     wrapped_field = field.opts.field
     output = [o for o in run_collection(field, data, wrapped_field.serialize)]
 
@@ -43,31 +52,23 @@ def serialize_collection(field, data):
 
 class CollectionInput(Input):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
+    input_pipes = marshal_input_pipe
     validation_pipes = [
         is_list,
     ]
     process_pipes = [
         marshall_collection,
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = marshal_output_pipe
 
 
 class CollectionOutput(Output):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
+    input_pipes = serialize_input_pipe
     validation_pipes = [
         is_list,
     ]
     process_pipes = [
         serialize_collection,
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = serialize_output_pipe

--- a/kim/pipelines/nested.py
+++ b/kim/pipelines/nested.py
@@ -5,16 +5,21 @@
 # This module is part of Kim and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from .base import Input, Output, get_data_from_source, update_output
+from .base import (Input, Output, marshal_input_pipe, marshal_output_pipe,
+                   serialize_input_pipe, serialize_output_pipe)
 
 
 def marshal_nested(field, data):
+    """Marshal data using the nested mapper defined on this field.
+    """
 
     nested_mapper = field.get_mapper(data=data)
     return nested_mapper.marshal(role=field.opts.role)
 
 
 def serialize_nested(field, data):
+    """Serialize data using the nested mapper defined on this field.
+    """
 
     nested_mapper = field.get_mapper(obj=data)
     return nested_mapper.serialize(role=field.opts.role)
@@ -22,27 +27,17 @@ def serialize_nested(field, data):
 
 class NestedInput(Input):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
-    validation_pipes = [
-    ]
+    input_pipes = marshal_input_pipe
     process_pipes = [
         marshal_nested
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = marshal_output_pipe
 
 
 class NestedOutput(Output):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
+    input_pipes = serialize_input_pipe
     process_pipes = [
         serialize_nested
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = serialize_output_pipe

--- a/kim/pipelines/numeric.py
+++ b/kim/pipelines/numeric.py
@@ -5,7 +5,9 @@
 # This module is part of Kim and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from .base import Input, Output, get_data_from_source, update_output
+from .base import (
+    Input, Output, marshal_input_pipe, marshal_output_pipe,
+    serialize_input_pipe, serialize_output_pipe)
 
 
 def is_valid_integer(field, data):
@@ -25,22 +27,15 @@ def is_valid_integer(field, data):
 
 class IntegerInput(Input):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
+    input_pipes = marshal_input_pipe
+
     validation_pipes = [
         is_valid_integer
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = marshal_output_pipe
 
 
 class IntegerOutput(Output):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
-    output_pipes = [
-        update_output,
-    ]
+    input_pipes = serialize_input_pipe
+    output_pipes = serialize_output_pipe

--- a/kim/pipelines/string.py
+++ b/kim/pipelines/string.py
@@ -5,7 +5,10 @@
 # This module is part of Kim and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from .base import Input, Output, get_data_from_source, update_output
+from .base import (
+    Input, Output,
+    marshal_input_pipe, serialize_input_pipe,
+    marshal_output_pipe, serialize_output_pipe)
 
 
 def is_valid_string(field, data):
@@ -23,22 +26,15 @@ def is_valid_string(field, data):
 
 class StringInput(Input):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
+    input_pipes = marshal_input_pipe
+
     validation_pipes = [
         is_valid_string,
     ]
-    output_pipes = [
-        update_output,
-    ]
+    output_pipes = marshal_output_pipe
 
 
 class StringOutput(Output):
 
-    input_pipes = [
-        get_data_from_source,
-    ]
-    output_pipes = [
-        update_output,
-    ]
+    input_pipes = serialize_input_pipe
+    output_pipes = serialize_output_pipe

--- a/tests/test_pipelines/test_collection.py
+++ b/tests/test_pipelines/test_collection.py
@@ -48,13 +48,24 @@ def test_serialize_flat_collection():
     assert output == {'post_ids': [2, 1]}
 
 
+def test_marshal_read_only_collection():
+
+    f = field.Collection(field.Integer(name='post_ids'), read_only=True)
+    output = {}
+    data = {
+        'post_ids': [2, 1]
+    }
+    f.marshal(data, output)
+    assert output == {}
+
+
 def test_marshal_nested_collection():
 
     class UserMapper(Mapper):
 
         __type__ = TestType
 
-        id = field.String(required=True, read_only=True)
+        id = field.String(required=True)
         name = field.String()
     data = {'id': 2, 'name': 'bob', 'users': [{'id': '1', 'name': 'mike'}]}
 

--- a/tests/test_pipelines/test_nested.py
+++ b/tests/test_pipelines/test_nested.py
@@ -60,7 +60,7 @@ def test_marshal_nested():
 
         __type__ = dict
 
-        id = field.String(required=True, read_only=True)
+        id = field.String(required=True)
         name = field.String()
 
     data = {'id': 2, 'name': 'bob', 'user': {'id': '1', 'name': 'mike'}}
@@ -128,3 +128,37 @@ def test_marshal_nested_with_role():
     output = {}
     test_field.marshal(data, output)
     assert output == {'user': {'name': 'mike'}}
+
+
+def test_marshal_nested_with_read_only_field():
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = field.String(required=True, read_only=True)
+        name = field.String()
+
+    data = {'id': 2, 'name': 'bob', 'user': {'id': '1', 'name': 'mike'}}
+    test_field = field.Nested('UserMapper', name='user')
+
+    output = {}
+    test_field.marshal(data, output)
+    assert output == {'user': {'name': 'mike'}}
+
+
+def test_marshal_read_only_nested_mapper():
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = field.String(required=True, read_only=True)
+        name = field.String()
+
+    data = {'id': 2, 'name': 'bob', 'user': {'id': '1', 'name': 'mike'}}
+    test_field = field.Nested('UserMapper', name='user', read_only=True)
+
+    output = {}
+    test_field.marshal(data, output)
+    assert output == {}

--- a/tests/test_pipelines/test_numeric.py
+++ b/tests/test_pipelines/test_numeric.py
@@ -50,3 +50,12 @@ def test_integer_output():
     output = {}
     field.serialize(Foo(), output)
     assert output == {'name': 2}
+
+
+def test_marshal_read_only_integer():
+
+    field = Integer(name='name', read_only=True, required=True)
+
+    output = {}
+    field.marshal({'id': 2, 'email': 'mike@mike.com'}, output)
+    assert output == {}

--- a/tests/test_pipelines/test_string.py
+++ b/tests/test_pipelines/test_string.py
@@ -43,3 +43,12 @@ def test_string_output():
     output = {}
     field.serialize(Foo(), output)
     assert output == {'name': 'value'}
+
+
+def test_marshal_read_only_string():
+
+    field = String(name='name', read_only=True, required=True)
+
+    output = {}
+    field.marshal({'name': 'foo', 'email': 'mike@mike.com'}, output)
+    assert output == {}


### PR DESCRIPTION
- Introduced new exception to allow the pipeline process to halt execution at any given point.
- removed duplication when defining input and output pipes for built in Field types.  These are now defined as reusable list of pipes in pipelines/base
- Provided tests for marshaling all currently implemented field types.