### PR TITLE
Support for raw=True when serializing

### DIFF
--- a/kim/field.py
+++ b/kim/field.py
@@ -55,6 +55,8 @@ class FieldOpts(object):
         :param allow_none: Speficy if this fields value can be None
         :param read_only: Speficy if this field should be ignored when marshaling
         :param error_msgs: a dict of error_type: error messages.
+        :param null_default: specify the default type to return when a field is
+            null IE None or {} or ''
 
         :raises: :class:`.FieldOptsError`
         :returns: None
@@ -77,6 +79,7 @@ class FieldOpts(object):
 
         self.required = opts.pop('required', False)
         self.default = opts.pop('default', None)
+        self.null_default = opts.pop('null_default', None)
 
         self.allow_none = opts.pop('allow_none', True)
         self.read_only = opts.pop('read_only', False)

--- a/kim/pipelines/nested.py
+++ b/kim/pipelines/nested.py
@@ -21,6 +21,9 @@ def serialize_nested(field, data):
     """Serialize data using the nested mapper defined on this field.
     """
 
+    if data is None:
+        return field.opts.null_default
+
     nested_mapper = field.get_mapper(obj=data)
     return nested_mapper.serialize(role=field.opts.role)
 

--- a/kim/utils.py
+++ b/kim/utils.py
@@ -8,6 +8,8 @@
 
 _creation_order = 1
 
+from collections import defaultdict
+
 
 def set_creation_order(instance):
     """Assign a '_creation_order' sequence to the given instance.
@@ -30,3 +32,10 @@ def attr_or_key(obj, name):
         return obj.get(name)
     else:
         return getattr(obj, name, None)
+
+
+def recursive_defaultdict():
+    """A simple recurrsive version of ``collections.defaultdict``
+
+    """
+    return defaultdict(recursive_defaultdict)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -12,6 +12,20 @@ class TestType(object):
             setattr(self, k, v)
 
 
+class IterableTestType(object):
+    """This test type mimics constructs like SQA's result class or
+    declarative_base objects that support iteration that enables access to
+    attributes.
+    """
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def keys(self):
+        return self.kwargs.keys()
+
+
 class TestField(Field):
     pass
 
@@ -253,6 +267,222 @@ def test_mapper_serialize():
     result = mapper.serialize()
 
     assert result == {'id': 2, 'name': 'bob'}
+
+
+def test_mapper_serialize_raw_standard_obj():
+    """Ensure we can still serialize a mapper  with raw=True when the object
+    has standardly named field names, IE no __dunder__
+    """
+
+    class MapperBase(Mapper):
+
+        __type__ = TestType
+
+        id = Integer()
+        name = String()
+
+    obj = IterableTestType(id=2, name='bob')
+
+    mapper = MapperBase(obj, raw=True)
+    result = mapper.serialize()
+
+    assert result == {'id': 2, 'name': 'bob'}
+
+
+def test_mapper_serialize_raw():
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+
+    class MapperBase(Mapper):
+
+        __type__ = TestType
+
+        id = Integer()
+        name = String()
+        user = Nested(UserMapper)
+
+    obj = IterableTestType(
+        id=2, name='bob',
+        user__id='foo',
+        user__name='bar',
+        user__company__name='baz',
+        user__company__id='bin')
+
+    obj = IterableTestType(id=2, name='bob', user__id='foo', user__name='bar')
+    mapper = MapperBase(obj, raw=True)
+    result = mapper.serialize()
+
+    assert result == {
+        'id': 2,
+        'name': 'bob',
+        'user': {
+            'id': 'foo',
+            'name': 'bar'
+        }
+    }
+
+
+def test_mapper_serialize_raw_nested_nested():
+
+    class CompanyMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+        company = Nested(CompanyMapper)
+
+    class MapperBase(Mapper):
+
+        __type__ = TestType
+
+        id = Integer()
+        name = String()
+        user = Nested(UserMapper)
+
+    obj = IterableTestType(
+        id=2, name='bob',
+        user__id='foo',
+        user__name='bar',
+        user__company__name='baz',
+        user__company__id='bin')
+
+    mapper = MapperBase(obj, raw=True)
+    result = mapper.serialize()
+
+    assert result == {
+        'id': 2,
+        'name': 'bob',
+        'user': {
+            'id': 'foo',
+            'name': 'bar',
+            'company': {
+                'id': 'bin',
+                'name': 'baz'
+            }
+        }
+    }
+
+
+def test_mapper_serialize_empty_nested_sets_null_default():
+    """Ensure that when when a nested mapper has no data, the defined
+    null_default is returned in its place.
+
+    """
+
+    class CompanyMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+        company = Nested(CompanyMapper)
+
+    class MapperBase(Mapper):
+
+        __type__ = TestType
+
+        id = Integer()
+        name = String()
+        user = Nested(UserMapper, null_default={})
+
+    user_type = TestType(id='3', name='foo')
+    obj1 = TestType(id='2', name='foo', user=user_type)
+    mapper = MapperBase(obj1)
+    result = mapper.serialize()
+    assert result == {
+        'id': '2',
+        'name': 'foo',
+        'user': {
+            'id': '3',
+            'name': 'foo',
+            'company': None
+        }
+    }
+
+    obj2 = IterableTestType(id=2, name='bob', user__id='3', user__name='foo')
+
+    mapper = MapperBase(obj2, raw=True)
+    result = mapper.serialize()
+
+    assert result == {
+        'id': 2,
+        'name': 'bob',
+        'user': {
+            'id': '3',
+            'name': 'foo',
+            'company': None
+        }
+    }
+
+
+def test_serialize_empty_nested_nested():
+    """Ensure that when when a nested mapper has no data, the defined
+    null_default is returned in its place.
+
+    """
+
+    class CompanyMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+
+    class UserMapper(Mapper):
+
+        __type__ = dict
+
+        id = String(required=True, read_only=True)
+        name = String()
+        company = Nested(CompanyMapper)
+
+    class MapperBase(Mapper):
+
+        __type__ = TestType
+
+        id = Integer()
+        name = String()
+        user = Nested(UserMapper, null_default={})
+
+    obj1 = TestType(id='2', name='foo', user=None)
+    mapper = MapperBase(obj1)
+    result = mapper.serialize()
+    assert result == {
+        'id': '2',
+        'name': 'foo',
+        'user': {}
+    }
+
+    obj2 = IterableTestType(id=2, name='bob')
+
+    mapper = MapperBase(obj2, raw=True)
+    result = mapper.serialize()
+
+    assert result == {
+        'id': 2,
+        'name': 'bob',
+        'user': {}
+    }
 
 
 def test_mapper_serialize_many():


### PR DESCRIPTION
* support __dunder__ field lookups by transforming data when `serialize()` is called
* Fixes issue in kim 1 where NULL nested types would still have fields populated
* allow users to specify NULL default IE `user: {}` instead of `user: None`
* allow users to call raw when `serialize()` method is called or globally for a mapper Mapper(raw=True)