### PR TITLE
fix issue where allow_updates_in_place and allow_create could not be …

### DIFF
--- a/kim/field.py
+++ b/kim/field.py
@@ -356,10 +356,6 @@ class NestedFieldOpts(FieldOpts):
 
     """
 
-    extra_error_msgs = {
-        'invalid_collection_length': 'invalid number of {name}s'
-    }
-
     def __init__(self, mapper_or_mapper_name, **kwargs):
         """Construct a new instance of :class:`.NestedFieldOpts`
 

--- a/kim/pipelines/nested.py
+++ b/kim/pipelines/nested.py
@@ -58,14 +58,10 @@ def marshal_nested(session):
         else:
             session.data = resolved
     else:
-        if session.field.opts.allow_updates_in_place or \
-                session.field.opts.allow_partial_updates:
-            existing_value = attr_or_key(session.output, session.field.name)
-            # If no existing value is found in the output, this is probably
-            # a nested collection with more objects in the json input
-            # than already exist
-            if not existing_value:
-                raise session.field.invalid('invalid_collection_length')
+        existing_value = attr_or_key(session.output, session.field.name)
+        if (session.field.opts.allow_updates_in_place or
+                session.field.opts.allow_partial_updates) and \
+                existing_value is not None:
             nested_mapper = session.field.get_mapper(
                 data=session.data, obj=existing_value, partial=partial,
                 parent=parent)

--- a/tests/test_pipelines/test_collection.py
+++ b/tests/test_pipelines/test_collection.py
@@ -187,6 +187,32 @@ def test_marshal_nested_collection_allow_updates_in_place_too_many():
         f.marshal(mapper_session)
 
 
+def test_marshal_nested_collection_allow_updates_in_place_too_many_with_allow_create():
+    # We're updating in place, there are more users in the input data
+    # but allow_create is also enabled, so a new user should be added
+
+    class UserMapper(Mapper):
+
+        __type__ = TestType
+
+        name = field.String()
+
+    user = TestType(id='1', name='mike')
+    data = {'id': 2, 'name': 'bob', 'users': [
+        {'name': 'name1'}, {'name': 'name2'}]}
+
+    f = field.Collection(field.Nested('UserMapper',
+                         allow_updates_in_place=True, allow_create=True),
+                         name='users')
+    output = {'users': [user]}
+    mapper_session = get_mapper_session(data=data, output=output)
+
+    f.marshal(mapper_session)
+
+    assert output == {
+        'users': [TestType(id='1', name='name1'), TestType(name='name2')]}
+
+
 def test_serialize_nested_collection():
 
     class UserMapper(Mapper):


### PR DESCRIPTION
…used together

see snappily named new testcase test_marshal_nested_collection_allow_updates_in_place_too_many_with_allow_create - previously this combination of flags would cause an errorneous "invalid collection length" error