### PR TITLE
support __self__ as source

### DIFF
--- a/kim/pipelines/base.py
+++ b/kim/pipelines/base.py
@@ -181,12 +181,14 @@ def get_data_from_source(session):
 
     """
 
+    source = session.field.opts.source
+
     # If the field is wrapped by another field then the relevant data
     # will have already been pulled from the source.
-    if session.field.opts._is_wrapped:
+    if session.field.opts._is_wrapped or source == '__self__':
         return session.data
 
-    value = attr_or_key(session.data, session.field.opts.source)
+    value = attr_or_key(session.data, source)
     session.data = value
     return session.data
 

--- a/tests/test_pipelines/test_base.py
+++ b/tests/test_pipelines/test_base.py
@@ -79,6 +79,17 @@ def test_get_data_from_source_pipe_dot_syntax():
     assert get_data_from_source(session) == 'mike'
 
 
+def test_get_data_from_source_pipe_self():
+    data = {
+        'name': 'mike'
+    }
+    output = {}
+
+    field = Field(source='__self__')
+    session = Session(field, data, output)
+    assert get_data_from_source(session) is data
+
+
 def test_update_output_to_name_with_object():
 
     data = {


### PR DESCRIPTION
support passing `source='__self__'` to nested to cause the nested mapper to use the same object as the parent (kim 1 feature parity)