### PR TITLE
put everything in __init__ and define __all__

### DIFF
--- a/docs/source/user/advanced.rst
+++ b/docs/source/user/advanced.rst
@@ -28,8 +28,7 @@ all of our Polymorphic types extend from.  Our base type should inherit from :cl
 
 .. code-block:: python
 
-    from kim.mapper import PolymorphicMapper
-    from kim import field
+    from kim import PolymorphicMapper, field
 
     class ActivityMapper(PolymorphicMapper):
 
@@ -170,7 +169,7 @@ You should typically only worry about handling the :class:`kim.exception.Mapping
 
 .. code-block:: python
 
-    from kim.exception import MappingInvalid
+    from kim import MappingInvalid
 
     try:
         data = mapper.marshal()

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -29,8 +29,7 @@ like object.
 
 .. code-block:: python
 
-	from kim import Mapper
-	from kim import field
+	from kim import Mapper, field
 
 	class CompanyMapper(Mapper):
 		__type__ = Company
@@ -123,7 +122,7 @@ raised when marshaling.
 
 .. code-block:: python
 
-	from kim.exception import MappingInvalid
+	from kim import MappingInvalid
 
 	data = {'name': 'Tony Stark'}
 	mapper = UserMapper(data=data)
@@ -264,8 +263,7 @@ To define roles on your mapper use the ``__roles__`` property.
 
 .. code-block:: python
 
-	from kim import Mapper
-	from kim import field, role
+	from kim import Mapper, field, whitelist, blacklist
 
 	class CompanyMapper(Mapper):
 		__type__ = Company
@@ -279,8 +277,8 @@ To define roles on your mapper use the ``__roles__`` property.
 		company = field.Nested(CompanyMapper, read_only=True)
 
         __roles__ = {
-            'id_only': role.whitelist('id'),
-            'public': role.blackist('id')
+            'id_only': whitelist('id'),
+            'public': blackist('id')
         }
 
 We've defined two roles on our UserMapper.  These roles can now be used when

--- a/kim/__init__.py
+++ b/kim/__init__.py
@@ -9,5 +9,19 @@
 __version__ = '1.0.0'
 
 
-from .mapper import Mapper
-from .field import Field
+from .mapper import Mapper, PolymorphicMapper
+from .exception import (
+    MapperError, MappingInvalid, RoleError, FieldOptsError, FieldError,
+    FieldInvalid, StopPipelineExecution)
+from .role import blacklist, whitelist
+from .pipelines import pipe
+from .field import (
+    Field, String, Integer, Decimal, Boolean, Nested, Collection, Static,
+    DateTime, Date)
+
+
+__all__ = [
+    Mapper, PolymorphicMapper, MapperError, MappingInvalid, RoleError,
+    FieldOptsError, FieldError, FieldInvalid, StopPipelineExecution, blacklist,
+    whitelist, pipe, Field, String, Integer, Decimal, Boolean, Nested,
+    Collection, Static, DateTime, Date]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,10 +1,9 @@
 import pytest
 import mock
 
-from kim.exception import MappingInvalid, MapperError
-from kim.mapper import Mapper, PolymorphicMapper
-from kim.role import blacklist
-from kim.field import Integer, Collection, String, Field
+from kim import (
+    MappingInvalid, MapperError, Mapper, PolymorphicMapper, blacklist, Integer,
+    Collection, String, Field)
 from kim.pipelines import marshaling
 from kim.pipelines import serialization
 


### PR DESCRIPTION
Imported entire user API but not things like utility functions or pipelines as they're really an implementation detail.

Docs updated.

Changed imports in test_functional.py as it's meant to be a test of the actual API as used by users.